### PR TITLE
Feat: Update Hall of Fame to display 2024 leaderboard data

### DIFF
--- a/src/constants/annual-leaderboard/2024/final.json
+++ b/src/constants/annual-leaderboard/2024/final.json
@@ -1,0 +1,74 @@
+{
+  "data": [
+      {
+          "name": "BroCode",
+          "email": "nisith.21@cse.mrt.ac.lk",
+          "university": "University of Moratuwa",
+          "eliminated": false,
+          "score": 600
+      },
+      {
+          "name": "KK_Coders",
+          "email": "kkcoderz@gmail.com",
+          "university": "University of Moratuwa",
+          "eliminated": false,
+          "score": 525
+      },
+      {
+          "name": "Red Shifts",
+          "email": "redshifts.sl@gmail.com",
+          "university": "University of Moratuwa",
+          "eliminated": false,
+          "score": 500
+      },
+      {
+          "name": "Terminal Titans",
+          "email": "fernandosachintha08@gmail.com",
+          "university": "CICRA Campus",
+          "eliminated": false,
+          "score": 475
+      },
+      {
+          "name": "5H4RK",
+          "email": "qjoyal@gmail.com",
+          "university": "SLIIT",
+          "eliminated": false,
+          "score": 475
+      },
+      {
+          "name": "DreamGen",
+          "email": "mithilathilochanaj@gmail.com",
+          "university": "SLIIT",
+          "eliminated": false,
+          "score": 475
+      },
+      {
+          "name": "Byte Bandits",
+          "email": "www.chamalbandara398@gmail.com",
+          "university": "SLIIT",
+          "eliminated": false,
+          "score": 475
+      },
+      {
+          "name": "Team Veritas",
+          "email": "pragash1001@gmail.com",
+          "university": "Informatics Institute of Technology",
+          "eliminated": false,
+          "score": 400
+      },
+      {
+          "name": "REISUB",
+          "email": "nirmalsavinda29@gmail.com",
+          "university": "UCSC",
+          "eliminated": false,
+          "score": 200
+      },
+      {
+          "name": "Tux",
+          "email": "peshalaprabhapoorna@gmail.com",
+          "university": "University of Ruhuna",
+          "eliminated": false,
+          "score": 175
+      }
+  ]
+}

--- a/src/constants/annual-leaderboard/2024/ghost-legion.json
+++ b/src/constants/annual-leaderboard/2024/ghost-legion.json
@@ -1,0 +1,1166 @@
+{
+  "data": [
+      {
+          "name": "BroCode",
+          "email": "nisith.21@cse.mrt.ac.lk",
+          "university": "University of Moratuwa",
+          "eliminated": false,
+          "score": 600
+      },
+      {
+          "name": "KK_Coders",
+          "email": "kkcoderz@gmail.com",
+          "university": "University of Moratuwa",
+          "eliminated": false,
+          "score": 525
+      },
+      {
+          "name": "Red Shifts",
+          "email": "redshifts.sl@gmail.com",
+          "university": "University of Moratuwa",
+          "eliminated": false,
+          "score": 500
+      },
+      {
+          "name": "Terminal Titans",
+          "email": "fernandosachintha08@gmail.com",
+          "university": "CICRA Campus",
+          "eliminated": false,
+          "score": 475
+      },
+      {
+          "name": "5H4RK",
+          "email": "qjoyal@gmail.com",
+          "university": "SLIIT",
+          "eliminated": false,
+          "score": 475
+      },
+      {
+          "name": "DreamGen",
+          "email": "mithilathilochanaj@gmail.com",
+          "university": "SLIIT",
+          "eliminated": false,
+          "score": 475
+      },
+      {
+          "name": "Byte Bandits",
+          "email": "www.chamalbandara398@gmail.com",
+          "university": "SLIIT",
+          "eliminated": false,
+          "score": 475
+      },
+      {
+          "name": "Team Veritas",
+          "email": "pragash1001@gmail.com",
+          "university": "Informatics Institute of Technology",
+          "eliminated": false,
+          "score": 400
+      },
+      {
+          "name": "REISUB",
+          "email": "nirmalsavinda29@gmail.com",
+          "university": "UCSC",
+          "eliminated": false,
+          "score": 200
+      },
+      {
+          "name": "Tux",
+          "email": "peshalaprabhapoorna@gmail.com",
+          "university": "University of Ruhuna",
+          "eliminated": false,
+          "score": 175
+      },
+      {
+          "name": "Innov8ive",
+          "email": "yasanhemachandra@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Codepro",
+          "email": "lokudadalla2001sandaru@gmail.com",
+          "university": "University of Moratuwa",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "3_idiots",
+          "email": "3idiots.cse21@gmail.com",
+          "university": "University of Moratuwa",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "PointBreak",
+          "email": "ryansilvaslyt@gmail.com",
+          "university": "NIBM",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Wizard",
+          "email": "prasadnirmal2021@gmail.com",
+          "university": "SLTC",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Shebang Squad",
+          "email": "dulinapereraex@gmail.com",
+          "university": "University of Moratuwa",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Cryptonovate",
+          "email": "cryptonovate@gmail.com",
+          "university": "UCSC",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Lambda Baryon",
+          "email": "christancf.dev@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "DevSpark",
+          "email": "Shandilhara826@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Xorus",
+          "email": "k.pradeeshan4@gmail.com",
+          "university": "Uva Wellassa University",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "5 points to Gryffindor",
+          "email": "kavishkauvindu0@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "celestron",
+          "email": "vihanga.isu@gmail.com",
+          "university": "Informatics Institute of Technology",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "STA",
+          "email": "staaxsxi@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "The Breakpoints",
+          "email": "bavanthasenanayake@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "mercode",
+          "email": "pathirana.sithmal@gmail.com",
+          "university": "Informatics Institute of Technology",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Code Warriors",
+          "email": "suhansa2816@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "ByteBenders",
+          "email": "arrowsajee@gmail.com",
+          "university": "University of Jaffna",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Team Titans",
+          "email": "pasindugunawardhana25@gmail.com",
+          "university": "NIBM",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Gojo",
+          "email": "adisha.akeeth@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Sudo Squad",
+          "email": "infinityxiit@gmail.com",
+          "university": "Informatics Institute of Technology",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "MEGAMINDs",
+          "email": "ahmedumar7010@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "BashBlitz",
+          "email": "uhwalipitiya@gmail.com",
+          "university": "University of Kelaniya",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Sudo",
+          "email": "desilvabethmin@gmail.com",
+          "university": "University of Kelaniya",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Team22",
+          "email": "thedassilva64@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Shell Shockers",
+          "email": "kaveeshatech@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Code Hustlers",
+          "email": "kaveenpsnd@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "codebusters",
+          "email": "p.g.m.sadeep2001@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Cheemzilla",
+          "email": "sayankrayotas@gmail.com",
+          "university": "University of Moratuwa",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Droid Engine",
+          "email": "shannonakmeemana11@gmail.com",
+          "university": "Informatics Institute of Technology",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "4bit",
+          "email": "ashen60438@gmail.com",
+          "university": "University of Moratuwa",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Chamithu",
+          "email": "chamithued@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Sweet Coders",
+          "email": "sashmithakavishka@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "MinusOne",
+          "email": "kavindadewmith@gmail.com",
+          "university": "University of Colombo",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Aenuka Buddhakorala",
+          "email": "aenukamac@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Bashmites",
+          "email": "jmhdilsha@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "NeoCoders",
+          "email": "diluminshyamal@gmail.com",
+          "university": "University of Moratuwa",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "None",
+          "email": "it22576170@my.sliit.lk",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Codeforce",
+          "email": "IT22170620@my.sliit.lk",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "FOSS",
+          "email": "pdmspasindu@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "CipherX19",
+          "email": "sahandakshitha45@gmail.com",
+          "university": "Informatics Institute of Technology",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "EVOBash",
+          "email": "dilmithp@outlook.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Thalapathy",
+          "email": "ranjiththarun57@gmail.com",
+          "university": "Esoft Metro Campus",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "AutoMat3",
+          "email": "rusirasathnindu50@gmail.com",
+          "university": "UCSC",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "TechSpark",
+          "email": "techspark.uom@gmail.com",
+          "university": "University of Moratuwa",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Just for fun",
+          "email": "yasithadithya@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Sharks",
+          "email": "teamsharks.uom@gmail.com",
+          "university": "University of Moratuwa",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Fin7",
+          "email": "eyxxstar777@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "AKA WDS",
+          "email": "jakmalali@gmail.com",
+          "university": "University of Moratuwa",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Heisenberg",
+          "email": "chathuraabeygunawardhana@gmail.com",
+          "university": "University of Moratuwa",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Team DOTS",
+          "email": "pawan.senpura@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Janus",
+          "email": "dinukajkdy@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Nova",
+          "email": "nethmi12senarathna@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "CtrlShiftHack",
+          "email": "mushrif2002@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "No ones",
+          "email": "it23548046@my.sliit.lk",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "RebelliousCoders",
+          "email": "it20654580@my.sliit.lk",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Tranquilizers",
+          "email": "mpriyawadan@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "UOJ Kings",
+          "email": "2020e076@eng.jfn.ac.lk",
+          "university": "University of Jaffna",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Saffroncode",
+          "email": "himanhansadh.withana@gmail.com",
+          "university": "Informatics Institute of Technology",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Config Sys",
+          "email": "config.systeam@gmail.com",
+          "university": "Uva Wellassa University",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Bug Bashers",
+          "email": "sinelnemsara19@gmail.com",
+          "university": "NSBM",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Code_x",
+          "email": "code_x@outlook.in",
+          "university": "Informatics Institute of Technology",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "NemoOutis",
+          "email": "gayank.21@cse.mrt.ac.lk",
+          "university": "University of Moratuwa",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "FastASM",
+          "email": "pinsara.21@cse.mrt.ac.lk",
+          "university": "University of Moratuwa",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "CodeGlitch",
+          "email": "virajkaushalk@gmail.com",
+          "university": "University of Moratuwa",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Byte Bashers",
+          "email": "abdullam@perituza.com",
+          "university": "PERITUZA",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "ScriptHack",
+          "email": "charithwinwindula@gmail.com",
+          "university": "University of Kelaniya",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Byte Masters",
+          "email": "rusirusalwathura@icloud.com",
+          "university": "University of Moratuwa",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "ScriptyScripters",
+          "email": "jayathuchamikara@gmail.com",
+          "university": "Informatics Institute of Technology",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "SentraCode",
+          "email": "tharinedirisinghe10@gmail.com",
+          "university": "University of Moratuwa",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "ConsoleLog",
+          "email": "veerasaravanan.20220157@iit.ac.lk",
+          "university": "Informatics Institute of Technology",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "ScriptWriters",
+          "email": "it22084590@my.sliit.lk",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Amikzz",
+          "email": "amixx2005@gmail.com",
+          "university": "APIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Cyberdyne",
+          "email": "birunthur@gmail.com",
+          "university": "University of Moratuwa",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Enigmatics",
+          "email": "pasanlaksithakulathunge@gmail.com",
+          "university": "Informatics Institute of Technology",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "BashBrigades",
+          "email": "bashbrigades@gmail.com",
+          "university": "University of Moratuwa",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "CodeDrip",
+          "email": "hanaanee.21@cse.mrt.ac.lk",
+          "university": "University of Moratuwa",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "chickenKottu",
+          "email": "themeeranhassan@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Coding Blinders",
+          "email": "dhananjayaaps@gmail.com",
+          "university": "UCSC",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Team Vertex",
+          "email": "tharindudamruwan23@gmail.com",
+          "university": "University of Kelaniya",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "R3t4rds",
+          "email": "hithesh0215@gmail.com",
+          "university": "University of Moratuwa",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Surgical-masks",
+          "email": "surgicalmasks2022@gmail.com",
+          "university": "University of Moratuwa",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Agent Twilight",
+          "email": "kavindugunasena@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Byte Blenders",
+          "email": "nigeehettige20@gmail.com",
+          "university": "University of Jaffna",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Quadrant Crew",
+          "email": "kavinurangeeth@gmail.com",
+          "university": "University of Kelaniya",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Team_X",
+          "email": "kugarajah.21@cse.mrt.ac.lk",
+          "university": "University of Moratuwa",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Starter Squad",
+          "email": "e19450@eng.pdn.ac.lk",
+          "university": "University of Peradeniya",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Helki",
+          "email": "giviga4121@daypey.com",
+          "university": "NSBM",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Mamba Mob",
+          "email": "mohamednifadh@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "CodeStormers",
+          "email": "ayodhyaweerabahu@gmail.com",
+          "university": "NSBM",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "ByteCorders",
+          "email": "priyanthadinesh2002@gmail.com",
+          "university": "Sabaragamuwa University of Sri Lanka",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Infinity soft",
+          "email": "Chandima0406Sajith@gmail.com",
+          "university": "Sabaragamuwa University of Sri Lanka",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Unknown",
+          "email": "hiran9204@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Command Line Crusaders",
+          "email": "thusarav@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Team Metatron",
+          "email": "info.mtron.me@gmail.com",
+          "university": "University of Ruhuna",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Runtime Terror",
+          "email": "lightspeed.runtime@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Team CodeCrafters",
+          "email": "uthsarapavan@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Tech Titans",
+          "email": "allesabinash1@gmail.com",
+          "university": "University of Sri Jayewardenepura",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "wedonotsow",
+          "email": "baqirhabeeb@gmail.com",
+          "university": "University of Moratuwa",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Akatzuki",
+          "email": "sivakajan00@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Mathusigan S",
+          "email": "mathusenthan@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Ulindu Vibodha Silva",
+          "email": "vibodhasilvaulindu@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Script Titan",
+          "email": "thisaldeelakaleco@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Team_No_Name",
+          "email": "thenul.ranmuthu@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "MorseCoders",
+          "email": "morsecoders99@gmail.com",
+          "university": "University of Sri Jayewardenepura",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "NIBM Innovators",
+          "email": "isurindurathmal@gmail.com",
+          "university": "NIBM",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "LUMA Innovation",
+          "email": "luminde9958@gmail.com",
+          "university": "University of Vavuniya",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "AutoMinds",
+          "email": "sahanssiriwardena@gmail.com",
+          "university": "University of Peradeniya",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "HereForTheBytes",
+          "email": "hereforthebytes@gmail.com",
+          "university": "UCSC",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "one & zero",
+          "email": "m.m.senaleevisal@gmail.com",
+          "university": "NIBM",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Red Wolf",
+          "email": "tharanga.sandun.kumara2000@gmail.com",
+          "university": "University of Kelaniya",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "ALHAM",
+          "email": "alham@duck.com",
+          "university": "Albukhary International University",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "AiShark",
+          "email": "rkamithaisuru@gmail.com",
+          "university": "University of Sri Jayewardenepura",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "HcX",
+          "email": "pramodyalakmina@gmail.com",
+          "university": "University of Moratuwa",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Vortex",
+          "email": "bandaraashen02@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Code Crushers",
+          "email": "sachindu0143@gmail.com",
+          "university": "Sabaragamuwa University of Sri Lanka",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Coder Blasters",
+          "email": "dhananjayayapa99@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Tech Warriors",
+          "email": "sadunirasikala@gmail.com",
+          "university": "University of Moratuwa",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Endovers",
+          "email": "alenoshan@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "code4",
+          "email": "Janathmdrng@gmail.com",
+          "university": "University of Moratuwa",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Nyx",
+          "email": "wmovindulochana@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Byte Coders",
+          "email": "dewminkasmitha30@gmail.com",
+          "university": "University of Moratuwa",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "BashHaaners",
+          "email": "janithebates@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Yazi",
+          "email": "yasithanjanaa@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Deshan Thrimanna",
+          "email": "dilanka723@gmail.com",
+          "university": "University of Moratuwa",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Team Glory",
+          "email": "rapiram83@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Team Decipher",
+          "email": "riwaznuha@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "CSEw",
+          "email": "chamathranasinghe.21@cse.mrt.ac.lk",
+          "university": "University of Moratuwa",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "ByteCodes",
+          "email": "sonacode44@gmail.com",
+          "university": "UCSC",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Code Avengers",
+          "email": "IT22289384@my.sliit.lk",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "iCoders",
+          "email": "icodersmora@gmail.com",
+          "university": "University of Moratuwa",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "The 404s",
+          "email": "danula243@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Code0",
+          "email": "sihassenevirathne@gmail.com",
+          "university": "APIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Ghost Recon D3LT4",
+          "email": "ghostrecondelta@protonmail.com",
+          "university": "NSBM",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Code Conquerors",
+          "email": "codeconquerors97@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "500",
+          "email": "sudarakatharindu2001@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Shell_Strikers",
+          "email": "cryptess4@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Dev_Asmodeous",
+          "email": "azaamahmed555@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Empyrean",
+          "email": "nmasnanjana.123@gmail.com",
+          "university": "CICRA Campus",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Tech Titan",
+          "email": "vithushan.ravisuthan@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Genesys",
+          "email": "nimnakaveesha123456@gmail.com",
+          "university": "Institute of Software Engineering",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "ShadowCoders",
+          "email": "pasindusadanjana17@gmail.com",
+          "university": "University of Moratuwa",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Shiganshina",
+          "email": "wasath.vt@gmail.com",
+          "university": "NSBM",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Bash Coder",
+          "email": "mohamedzibras2015@gmail.com",
+          "university": "University of Moratuwa",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Trojanz",
+          "email": "ilakshitha7921@gmail.com",
+          "university": "UCSC",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Nadun Weerakkody",
+          "email": "weerakkody.kn@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "S13",
+          "email": "shamimbasha13@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Falcon4",
+          "email": "millennium54falcon@gmail.com",
+          "university": "University of Moratuwa",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "xanvia",
+          "email": "xanvia.official@gmail.com",
+          "university": "University of Peradeniya",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Generation X",
+          "email": "savidyajayalath@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Black Horse",
+          "email": "FBIDileepa10@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Codesters",
+          "email": "dewminichristine996@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Zero_IQ",
+          "email": "binaraepa@gmail.com",
+          "university": "University of Peradeniya",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Get & Net",
+          "email": "achini0611@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Bajiz",
+          "email": "lakshithaishan753@gmail.com",
+          "university": "UCSC",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Code_Ninja04",
+          "email": "tsarujan2001@gmail.com",
+          "university": "University of Jaffna",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "SleepyCoder",
+          "email": "aponsulithiraabb@gmail.com",
+          "university": "University of Peradeniya",
+          "eliminated": true,
+          "score": 0
+      }
+  ]
+}

--- a/src/constants/annual-leaderboard/2024/round1.json
+++ b/src/constants/annual-leaderboard/2024/round1.json
@@ -1,0 +1,1166 @@
+{
+  "data": [
+      {
+          "name": "HereForTheBytes",
+          "email": "hereforthebytes@gmail.com",
+          "university": "UCSC",
+          "eliminated": true,
+          "score": 550
+      },
+      {
+          "name": "REISUB",
+          "email": "nirmalsavinda29@gmail.com",
+          "university": "UCSC",
+          "eliminated": false,
+          "score": 525
+      },
+      {
+          "name": "Byte Bandits",
+          "email": "www.chamalbandara398@gmail.com",
+          "university": "SLIIT",
+          "eliminated": false,
+          "score": 475
+      },
+      {
+          "name": "DreamGen",
+          "email": "mithilathilochanaj@gmail.com",
+          "university": "SLIIT",
+          "eliminated": false,
+          "score": 425
+      },
+      {
+          "name": "5H4RK",
+          "email": "qjoyal@gmail.com",
+          "university": "SLIIT",
+          "eliminated": false,
+          "score": 425
+      },
+      {
+          "name": "BroCode",
+          "email": "nisith.21@cse.mrt.ac.lk",
+          "university": "University of Moratuwa",
+          "eliminated": false,
+          "score": 425
+      },
+      {
+          "name": "Red Shifts",
+          "email": "redshifts.sl@gmail.com",
+          "university": "University of Moratuwa",
+          "eliminated": false,
+          "score": 400
+      },
+      {
+          "name": "Tux",
+          "email": "peshalaprabhapoorna@gmail.com",
+          "university": "University of Ruhuna",
+          "eliminated": false,
+          "score": 400
+      },
+      {
+          "name": "Terminal Titans",
+          "email": "fernandosachintha08@gmail.com",
+          "university": "CICRA Campus",
+          "eliminated": false,
+          "score": 325
+      },
+      {
+          "name": "Team Veritas",
+          "email": "pragash1001@gmail.com",
+          "university": "Informatics Institute of Technology",
+          "eliminated": false,
+          "score": 325
+      },
+      {
+          "name": "KK_Coders",
+          "email": "kkcoderz@gmail.com",
+          "university": "University of Moratuwa",
+          "eliminated": false,
+          "score": 300
+      },
+      {
+          "name": "Byte Bashers",
+          "email": "abdullam@perituza.com",
+          "university": "PERITUZA",
+          "eliminated": true,
+          "score": 300
+      },
+      {
+          "name": "SentraCode",
+          "email": "tharinedirisinghe10@gmail.com",
+          "university": "University of Moratuwa",
+          "eliminated": true,
+          "score": 275
+      },
+      {
+          "name": "Bashmites",
+          "email": "jmhdilsha@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 275
+      },
+      {
+          "name": "Nyx",
+          "email": "wmovindulochana@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 250
+      },
+      {
+          "name": "Vortex",
+          "email": "bandaraashen02@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 200
+      },
+      {
+          "name": "wedonotsow",
+          "email": "baqirhabeeb@gmail.com",
+          "university": "University of Moratuwa",
+          "eliminated": true,
+          "score": 200
+      },
+      {
+          "name": "The 404s",
+          "email": "danula243@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 150
+      },
+      {
+          "name": "Team Vertex",
+          "email": "tharindudamruwan23@gmail.com",
+          "university": "University of Kelaniya",
+          "eliminated": true,
+          "score": 150
+      },
+      {
+          "name": "Mamba Mob",
+          "email": "mohamednifadh@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 150
+      },
+      {
+          "name": "Black Horse",
+          "email": "FBIDileepa10@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 125
+      },
+      {
+          "name": "Coding Blinders",
+          "email": "dhananjayaaps@gmail.com",
+          "university": "UCSC",
+          "eliminated": true,
+          "score": 100
+      },
+      {
+          "name": "one & zero",
+          "email": "m.m.senaleevisal@gmail.com",
+          "university": "NIBM",
+          "eliminated": true,
+          "score": 100
+      },
+      {
+          "name": "CodeStormers",
+          "email": "ayodhyaweerabahu@gmail.com",
+          "university": "NSBM",
+          "eliminated": true,
+          "score": 75
+      },
+      {
+          "name": "Gojo",
+          "email": "adisha.akeeth@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 50
+      },
+      {
+          "name": "5 points to Gryffindor",
+          "email": "kavishkauvindu0@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 50
+      },
+      {
+          "name": "Tech Warriors",
+          "email": "sadunirasikala@gmail.com",
+          "university": "University of Moratuwa",
+          "eliminated": true,
+          "score": 25
+      },
+      {
+          "name": "BashBlitz",
+          "email": "uhwalipitiya@gmail.com",
+          "university": "University of Kelaniya",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "ByteBenders",
+          "email": "arrowsajee@gmail.com",
+          "university": "University of Jaffna",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "MEGAMINDs",
+          "email": "ahmedumar7010@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Cryptonovate",
+          "email": "cryptonovate@gmail.com",
+          "university": "UCSC",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Sudo Squad",
+          "email": "infinityxiit@gmail.com",
+          "university": "Informatics Institute of Technology",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "DevSpark",
+          "email": "Shandilhara826@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Tranquilizers",
+          "email": "mpriyawadan@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Innov8ive",
+          "email": "yasanhemachandra@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "celestron",
+          "email": "vihanga.isu@gmail.com",
+          "university": "Informatics Institute of Technology",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "The Breakpoints",
+          "email": "bavanthasenanayake@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Cheemzilla",
+          "email": "sayankrayotas@gmail.com",
+          "university": "University of Moratuwa",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Code Warriors",
+          "email": "suhansa2816@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Droid Engine",
+          "email": "shannonakmeemana11@gmail.com",
+          "university": "Informatics Institute of Technology",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Shebang Squad",
+          "email": "dulinapereraex@gmail.com",
+          "university": "University of Moratuwa",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Sudo",
+          "email": "desilvabethmin@gmail.com",
+          "university": "University of Kelaniya",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Team22",
+          "email": "thedassilva64@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Wizard",
+          "email": "prasadnirmal2021@gmail.com",
+          "university": "SLTC",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "PointBreak",
+          "email": "ryansilvaslyt@gmail.com",
+          "university": "NIBM",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "3_idiots",
+          "email": "3idiots.cse21@gmail.com",
+          "university": "University of Moratuwa",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Codepro",
+          "email": "lokudadalla2001sandaru@gmail.com",
+          "university": "University of Moratuwa",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Xorus",
+          "email": "k.pradeeshan4@gmail.com",
+          "university": "Uva Wellassa University",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "NeoCoders",
+          "email": "diluminshyamal@gmail.com",
+          "university": "University of Moratuwa",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Code Hustlers",
+          "email": "kaveenpsnd@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Aenuka Buddhakorala",
+          "email": "aenukamac@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "MinusOne",
+          "email": "kavindadewmith@gmail.com",
+          "university": "University of Colombo",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "codebusters",
+          "email": "p.g.m.sadeep2001@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Chamithu",
+          "email": "chamithued@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "None",
+          "email": "it22576170@my.sliit.lk",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Codeforce",
+          "email": "IT22170620@my.sliit.lk",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "FOSS",
+          "email": "pdmspasindu@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "CipherX19",
+          "email": "sahandakshitha45@gmail.com",
+          "university": "Informatics Institute of Technology",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "EVOBash",
+          "email": "dilmithp@outlook.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Thalapathy",
+          "email": "ranjiththarun57@gmail.com",
+          "university": "Esoft Metro Campus",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "AutoMat3",
+          "email": "rusirasathnindu50@gmail.com",
+          "university": "UCSC",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "TechSpark",
+          "email": "techspark.uom@gmail.com",
+          "university": "University of Moratuwa",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Just for fun",
+          "email": "yasithadithya@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Sharks",
+          "email": "teamsharks.uom@gmail.com",
+          "university": "University of Moratuwa",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Fin7",
+          "email": "eyxxstar777@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "AKA WDS",
+          "email": "jakmalali@gmail.com",
+          "university": "University of Moratuwa",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Heisenberg",
+          "email": "chathuraabeygunawardhana@gmail.com",
+          "university": "University of Moratuwa",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Team DOTS",
+          "email": "pawan.senpura@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Janus",
+          "email": "dinukajkdy@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Nova",
+          "email": "nethmi12senarathna@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "CtrlShiftHack",
+          "email": "mushrif2002@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "No ones",
+          "email": "it23548046@my.sliit.lk",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "RebelliousCoders",
+          "email": "it20654580@my.sliit.lk",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "500",
+          "email": "sudarakatharindu2001@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "UOJ Kings",
+          "email": "2020e076@eng.jfn.ac.lk",
+          "university": "University of Jaffna",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Byte Masters",
+          "email": "rusirusalwathura@icloud.com",
+          "university": "University of Moratuwa",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Saffroncode",
+          "email": "himanhansadh.withana@gmail.com",
+          "university": "Informatics Institute of Technology",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Sweet Coders",
+          "email": "sashmithakavishka@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Bug Bashers",
+          "email": "sinelnemsara19@gmail.com",
+          "university": "NSBM",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Code_x",
+          "email": "code_x@outlook.in",
+          "university": "Informatics Institute of Technology",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "NemoOutis",
+          "email": "gayank.21@cse.mrt.ac.lk",
+          "university": "University of Moratuwa",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "FastASM",
+          "email": "pinsara.21@cse.mrt.ac.lk",
+          "university": "University of Moratuwa",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "CodeGlitch",
+          "email": "virajkaushalk@gmail.com",
+          "university": "University of Moratuwa",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "ScriptHack",
+          "email": "charithwinwindula@gmail.com",
+          "university": "University of Kelaniya",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Team Titans",
+          "email": "pasindugunawardhana25@gmail.com",
+          "university": "NIBM",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "ScriptyScripters",
+          "email": "jayathuchamikara@gmail.com",
+          "university": "Informatics Institute of Technology",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "ConsoleLog",
+          "email": "veerasaravanan.20220157@iit.ac.lk",
+          "university": "Informatics Institute of Technology",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "ScriptWriters",
+          "email": "it22084590@my.sliit.lk",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Amikzz",
+          "email": "amixx2005@gmail.com",
+          "university": "APIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Cyberdyne",
+          "email": "birunthur@gmail.com",
+          "university": "University of Moratuwa",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Enigmatics",
+          "email": "pasanlaksithakulathunge@gmail.com",
+          "university": "Informatics Institute of Technology",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "BashBrigades",
+          "email": "bashbrigades@gmail.com",
+          "university": "University of Moratuwa",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "CodeDrip",
+          "email": "hanaanee.21@cse.mrt.ac.lk",
+          "university": "University of Moratuwa",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Command Line Crusaders",
+          "email": "thusarav@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Agent Twilight",
+          "email": "kavindugunasena@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Byte Blenders",
+          "email": "nigeehettige20@gmail.com",
+          "university": "University of Jaffna",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Quadrant Crew",
+          "email": "kavinurangeeth@gmail.com",
+          "university": "University of Kelaniya",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Team_X",
+          "email": "kugarajah.21@cse.mrt.ac.lk",
+          "university": "University of Moratuwa",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Starter Squad",
+          "email": "e19450@eng.pdn.ac.lk",
+          "university": "University of Peradeniya",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "chickenKottu",
+          "email": "themeeranhassan@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "ByteCorders",
+          "email": "priyanthadinesh2002@gmail.com",
+          "university": "Sabaragamuwa University of Sri Lanka",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Infinity soft",
+          "email": "Chandima0406Sajith@gmail.com",
+          "university": "Sabaragamuwa University of Sri Lanka",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Unknown",
+          "email": "hiran9204@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Surgical-masks",
+          "email": "surgicalmasks2022@gmail.com",
+          "university": "University of Moratuwa",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Team Metatron",
+          "email": "info.mtron.me@gmail.com",
+          "university": "University of Ruhuna",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Runtime Terror",
+          "email": "lightspeed.runtime@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Team CodeCrafters",
+          "email": "uthsarapavan@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "AutoMinds",
+          "email": "sahanssiriwardena@gmail.com",
+          "university": "University of Peradeniya",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Empyrean",
+          "email": "nmasnanjana.123@gmail.com",
+          "university": "CICRA Campus",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Tech Titan",
+          "email": "vithushan.ravisuthan@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Genesys",
+          "email": "nimnakaveesha123456@gmail.com",
+          "university": "Institute of Software Engineering",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "ShadowCoders",
+          "email": "pasindusadanjana17@gmail.com",
+          "university": "University of Moratuwa",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Tech Titans",
+          "email": "allesabinash1@gmail.com",
+          "university": "University of Sri Jayewardenepura",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Akatzuki",
+          "email": "sivakajan00@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Mathusigan S",
+          "email": "mathusenthan@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Ulindu Vibodha Silva",
+          "email": "vibodhasilvaulindu@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Script Titan",
+          "email": "thisaldeelakaleco@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Team_No_Name",
+          "email": "thenul.ranmuthu@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "MorseCoders",
+          "email": "morsecoders99@gmail.com",
+          "university": "University of Sri Jayewardenepura",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "NIBM Innovators",
+          "email": "isurindurathmal@gmail.com",
+          "university": "NIBM",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "LUMA Innovation",
+          "email": "luminde9958@gmail.com",
+          "university": "University of Vavuniya",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Shiganshina",
+          "email": "wasath.vt@gmail.com",
+          "university": "NSBM",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Red Wolf",
+          "email": "tharanga.sandun.kumara2000@gmail.com",
+          "university": "University of Kelaniya",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "ALHAM",
+          "email": "alham@duck.com",
+          "university": "Albukhary International University",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "AiShark",
+          "email": "rkamithaisuru@gmail.com",
+          "university": "University of Sri Jayewardenepura",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "HcX",
+          "email": "pramodyalakmina@gmail.com",
+          "university": "University of Moratuwa",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Code Crushers",
+          "email": "sachindu0143@gmail.com",
+          "university": "Sabaragamuwa University of Sri Lanka",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Coder Blasters",
+          "email": "dhananjayayapa99@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Helki",
+          "email": "giviga4121@daypey.com",
+          "university": "NSBM",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "R3t4rds",
+          "email": "hithesh0215@gmail.com",
+          "university": "University of Moratuwa",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Ghost Recon D3LT4",
+          "email": "ghostrecondelta@protonmail.com",
+          "university": "NSBM",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Yazi",
+          "email": "yasithanjanaa@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Deshan Thrimanna",
+          "email": "dilanka723@gmail.com",
+          "university": "University of Moratuwa",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Team Glory",
+          "email": "rapiram83@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Team Decipher",
+          "email": "riwaznuha@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "ByteCodes",
+          "email": "sonacode44@gmail.com",
+          "university": "UCSC",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Code Avengers",
+          "email": "IT22289384@my.sliit.lk",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "iCoders",
+          "email": "icodersmora@gmail.com",
+          "university": "University of Moratuwa",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Code0",
+          "email": "sihassenevirathne@gmail.com",
+          "university": "APIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "BashHaaners",
+          "email": "janithebates@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Code Conquerors",
+          "email": "codeconquerors97@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Config Sys",
+          "email": "config.systeam@gmail.com",
+          "university": "Uva Wellassa University",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Shell_Strikers",
+          "email": "cryptess4@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Falcon4",
+          "email": "millennium54falcon@gmail.com",
+          "university": "University of Moratuwa",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "mercode",
+          "email": "pathirana.sithmal@gmail.com",
+          "university": "Informatics Institute of Technology",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "STA",
+          "email": "staaxsxi@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Lambda Baryon",
+          "email": "christancf.dev@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "4bit",
+          "email": "ashen60438@gmail.com",
+          "university": "University of Moratuwa",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Zero_IQ",
+          "email": "binaraepa@gmail.com",
+          "university": "University of Peradeniya",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Bash Coder",
+          "email": "mohamedzibras2015@gmail.com",
+          "university": "University of Moratuwa",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Trojanz",
+          "email": "ilakshitha7921@gmail.com",
+          "university": "UCSC",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Nadun Weerakkody",
+          "email": "weerakkody.kn@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "S13",
+          "email": "shamimbasha13@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Dev_Asmodeous",
+          "email": "azaamahmed555@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "xanvia",
+          "email": "xanvia.official@gmail.com",
+          "university": "University of Peradeniya",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Generation X",
+          "email": "savidyajayalath@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Codesters",
+          "email": "dewminichristine996@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Shell Shockers",
+          "email": "kaveeshatech@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Get & Net",
+          "email": "achini0611@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Bajiz",
+          "email": "lakshithaishan753@gmail.com",
+          "university": "UCSC",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Code_Ninja04",
+          "email": "tsarujan2001@gmail.com",
+          "university": "University of Jaffna",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "SleepyCoder",
+          "email": "aponsulithiraabb@gmail.com",
+          "university": "University of Peradeniya",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "CSEw",
+          "email": "chamathranasinghe.21@cse.mrt.ac.lk",
+          "university": "University of Moratuwa",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Endovers",
+          "email": "alenoshan@gmail.com",
+          "university": "SLIIT",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "code4",
+          "email": "Janathmdrng@gmail.com",
+          "university": "University of Moratuwa",
+          "eliminated": true,
+          "score": 0
+      },
+      {
+          "name": "Byte Coders",
+          "email": "dewminkasmitha30@gmail.com",
+          "university": "University of Moratuwa",
+          "eliminated": true,
+          "score": 0
+      }
+  ]
+}

--- a/src/pages/hall-of-fame.jsx
+++ b/src/pages/hall-of-fame.jsx
@@ -2,12 +2,14 @@ import ScoreBoard from "@/components/home/score-board";
 import { useFetchPastLeaderboardsQuery } from "@/store/api";
 
 const HallOfFame = () => {
+  const useFetchData = (params) => useFetchPastLeaderboardsQuery({ ...params, year: 2024 });
+
   return (
     <ScoreBoard
       pageTitle={"Hall of Fame | Bashaway"}
-      title={"Hall of Fame 2023"}
+      title={"Hall of Fame 2024"}
       subTitle={" A tribute to legendary warriors who once marched amongst us with unwavering valour"}
-      useFetchData={useFetchPastLeaderboardsQuery}
+      useFetchData={useFetchData}
     />
   );
 };


### PR DESCRIPTION
This pull request updates the Hall of Fame page for 2024. The primary changes include updating the leaderboard data and ensuring the page displays the correct title and fetches the latest results.

Annual leaderboard update:

* Added a new `final.json` file for the 2024 annual leaderboard in `src/constants/annual-leaderboard/2024/`, containing the top teams, their scores, and details.

Hall of Fame page adjustments:

* Changed the Hall of Fame page title and year to 2024 in `src/pages/hall-of-fame.jsx`.
* Updated the data fetching logic in `src/pages/hall-of-fame.jsx` to ensure leaderboard results are fetched for the year 2024.